### PR TITLE
Add automated process for downloading and publishing rent contracts

### DIFF
--- a/dubai_land_department.py
+++ b/dubai_land_department.py
@@ -65,10 +65,18 @@ def main():
     csv_filename = f'output/rent_contracts_{date.today()}.csv'
     parquet_filename = f'dld_rent_contracts_{date.today()}.parquet'
 
-    try:
-        release_checker = GitHubRelease('ggurjar333/real-estate-analysis-dubai')
-        release_checker.release_exists(f'release-{date.today()}')
-    except:
+    # try:
+    release_checker = GitHubRelease('ggurjar333/real-estate-analysis-dubai')
+    release_name = f'release-{date.today()}'
+    
+    if not release_checker.release_exists(release_name):
+        download_rent_contracts(url, csv_filename)
+        transform_rent_contracts(csv_filename, parquet_filename)
+        publish_to_github_release([parquet_filename])
+    else:
+        print(f"Release '{release_name}' already exists. No action taken.")
+            
+    # except:
         download_rent_contracts(url, csv_filename)
         transform_rent_contracts(csv_filename, parquet_filename)
         publish_to_github_release([parquet_filename])

--- a/lib/workspace/github_client.py
+++ b/lib/workspace/github_client.py
@@ -99,16 +99,7 @@ class GitHubRelease:
         Returns:
             bool: True if the release exists, False otherwise.
         """
-        try:
-            response = requests.get(f"{GITHUB_API_URL}/repos/{self.repo}/releases/tags/{tag_name}", headers=self.headers)
-            if response.status_code == 200:
-                logger.info(f"Release with tag {tag_name} already exists.")
-                return True
-            elif response.status_code == 404:
-                logger.info(f"Release with tag {tag_name} does not exist.")
-                return False
-            else:
-                response.raise_for_status()
-        except requests.exceptions.RequestException as e:
-            logger.error(f"GitHub API error: {e}")
-            raise
+        response = requests.get(f"{GITHUB_API_URL}/repos/{self.repo}/releases/tags/{tag_name}", headers=self.headers)
+        if response.status_code == 200:
+            logger.info(f"Release with tag {tag_name} already exists.")
+            return True


### PR DESCRIPTION
Add automated process for downloading and publishing rent contracts

- Check for existing release for today's date
- Download rent contracts from specified URL if release does not exist
- Transform downloaded CSV to Parquet format
- Publish the Parquet file to a new GitHub release